### PR TITLE
Setup cron for deleting pending orders

### DIFF
--- a/lib/printful/api.ex
+++ b/lib/printful/api.ex
@@ -46,6 +46,12 @@ defmodule Printful.Api do
     |> parse_result!()
   end
 
+  def delete(url) do
+    new()
+    |> Tesla.delete(url)
+    |> parse_result!()
+  end
+
   defp parse_result!(res) do
     case res do
       {:ok, %{status: 200, body: %{result: result}}} ->

--- a/lib/printful/order.ex
+++ b/lib/printful/order.ex
@@ -23,6 +23,10 @@ defmodule Printful.Order do
     Api.put("/orders/#{id}", params)
   end
 
+  def delete(id) do
+    Api.delete("/orders/#{id}")
+  end
+
   def confirm(id) do
     if Application.get_env(:store, Printful.Api)[:enable_purchasing] do
       Api.post("/orders/#{id}/confirm", %{})

--- a/lib/store/application.ex
+++ b/lib/store/application.ex
@@ -15,6 +15,8 @@ defmodule Elementary.Store.Application do
       {Cluster.Supervisor, [topologies, [name: Elementary.Store.ClusterSupervisor]]},
       # Start the Printful API cache
       Printful.Cache,
+      # Start the fulfillment cleaner
+      Elementary.Store.Fulfillment.Cleaner,
       # Start the PubSub system
       {Phoenix.PubSub, name: Elementary.Store.PubSub},
       # Start the Endpoint (http/https)

--- a/lib/store/fulfillment/cleaner.ex
+++ b/lib/store/fulfillment/cleaner.ex
@@ -1,0 +1,48 @@
+defmodule Elementary.Store.Fulfillment.Cleaner do
+  @moduledoc """
+  Cleans up old draft orders in Printful.
+  """
+
+  use GenServer
+
+  import Logger
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    Process.send_after(self(), :refresh, 1000)
+    {:ok, opts}
+  end
+
+  @impl true
+  def handle_info(:refresh, state) do
+    do_refresh()
+
+    Process.send_after(self(), :refresh, 6 * 60 * 60 * 1000)
+    {:noreply, state}
+  end
+
+  defp do_refresh() do
+    [status: "draft", limit: 100]
+    |> Printful.Order.list()
+    |> Enum.filter(&can_delete_order?/1)
+    |> Enum.each(&delete_order/1)
+  end
+
+  def can_delete_order?(order) do
+    created_at = DateTime.from_unix!(order.created)
+    deadline = DateTime.utc_now() |> DateTime.add(-1 * 6 * 60 * 60, :second)
+
+    DateTime.compare(created_at, deadline) == :lt
+  end
+
+  def delete_order(order) do
+    Printful.Order.delete(order.id)
+  rescue
+    e in Printful.ApiError ->
+      Logger.error("Error deleting printful draft order: #{inspect(e)}")
+  end
+end


### PR DESCRIPTION
Sets up a cron to delete draft orders. Sadly the delete endpoint only cancels an order, so it still shows in the web interface. I emailed to see if there were work arounds, but I'm not too hopeful.