### PR TITLE
Setup stripe auto tax for checkout

### DIFF
--- a/lib/store/catalog/product.ex
+++ b/lib/store/catalog/product.ex
@@ -7,7 +7,7 @@ defmodule Elementary.Store.Catalog.Product do
 
   @enforce_keys [:id]
 
-  defstruct [:id, :name, :description, :category, :price_range, :thumbnail_url, :variants]
+  defstruct [:id, :name, :description, :category, :type, :price_range, :thumbnail_url, :variants]
 
   @doc """
   Converts some Printful API data to an `Elementary.Store.Catalog.Product`
@@ -26,6 +26,7 @@ defmodule Elementary.Store.Catalog.Product do
       name: product.sync_product.name,
       description: catalog.product.description,
       category: Category.from_printful(catalog, product),
+      type: String.downcase(catalog.product.type_name),
       price_range: [hd(price_range), List.last(price_range)],
       thumbnail_url: product.sync_product.thumbnail_url
     )

--- a/lib/store/catalog/variant.ex
+++ b/lib/store/catalog/variant.ex
@@ -7,6 +7,7 @@ defmodule Elementary.Store.Catalog.Variant do
 
   defstruct [
     :id,
+    :product_id,
     :catalog_variant_id,
     :name,
     :description,
@@ -35,6 +36,7 @@ defmodule Elementary.Store.Catalog.Variant do
 
     struct(__MODULE__,
       id: store.id,
+      product_id: store.sync_product_id,
       catalog_variant_id: store.variant_id,
       name: store.name,
       description: catalog.product.description,


### PR DESCRIPTION
This PR sets up Stripe taxes for checkout.

![image](https://user-images.githubusercontent.com/3385679/125388991-bdc1f200-e35d-11eb-92f8-308f9704f28d.png)

One regression, because the total is generated _after_ we create the printful order, the total on printful's side will not be accurate. This can be remedied by dropping the stripe library we are currently using and rolling our own API client.

Also note, the tax that Stripe is giving us is less than what Printful was. For my address it comes out to $2.84 in stripe and $7.43 with Printful. I'm going to guess that's due to our origin address switching from what ever Printful uses to the one we have on file on Stripe.

And lastly, we will need to add registrations to start collecting taxes in areas: https://stripe.com/docs/tax/set-up