### PR TITLE
Errors: use friendlier copy

### DIFF
--- a/lib/store_web/templates/error/500.html.eex
+++ b/lib/store_web/templates/error/500.html.eex
@@ -1,9 +1,9 @@
 <section>
   <header class="error">
-    <h1>Internal Server Error</h1>
+    <h1>We’ll be right back…</h1>
 
     <p>
-      Something happened that prevented us from showing you this page.
+      The store is being updated and will be available again shortly.
     </p>
   </header>
 </section>

--- a/lib/store_web/templates/error/500.html.eex
+++ b/lib/store_web/templates/error/500.html.eex
@@ -3,7 +3,7 @@
     <h1>We’ll be right back…</h1>
 
     <p>
-      The store is being updated and will be available again shortly.
+      There was a server error preventing this page from loading, but it should be back shortly. Consider trying again in a few minutes.
     </p>
   </header>
 </section>

--- a/lib/store_web/templates/error/503.html.eex
+++ b/lib/store_web/templates/error/503.html.eex
@@ -1,10 +1,9 @@
 <section>
   <header class="error">
-    <h1>Temporarily Unavailable</h1>
+    <h1>We’ll be right back…</h1>
 
     <p>
-      Our store is unable to load right now, but it should be back soon. Please
-      check in again later.
+      The store is temporarily unavailable but will be back again shortly.
     </p>
   </header>
 </section>

--- a/lib/store_web/templates/error/503.html.eex
+++ b/lib/store_web/templates/error/503.html.eex
@@ -3,7 +3,7 @@
     <h1>We’ll be right back…</h1>
 
     <p>
-      The store is temporarily unavailable but will be back again shortly.
+      The store is temporarily unavailable, but it should be back shortly. Consider trying again in a few minutes.
     </p>
   </header>
 </section>


### PR DESCRIPTION
Fixes #187. Retains unique copy per error so we're still able to distinguish them e.g. in issue reports.