### PR TITLE
Fix credo suggestions

### DIFF
--- a/lib/store/fulfillment/fulfillment.ex
+++ b/lib/store/fulfillment/fulfillment.ex
@@ -105,8 +105,7 @@ defmodule Elementary.Store.Fulfillment do
   defp stripe_extra_lines(estimate) do
     estimate
     |> Map.take([:shipping, :tax, :vat])
-    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-    |> Enum.reject(fn {_k, v} -> v == 0 end)
+    |> Enum.reject(fn {_k, v} -> is_nil(v) or v == 0 end)
     |> Enum.map(fn {name, value} ->
       %{
         amount: round(value * 100),

--- a/lib/store_web/views/email_view.ex.ex
+++ b/lib/store_web/views/email_view.ex.ex
@@ -26,8 +26,7 @@ defmodule Elementary.StoreWeb.EmailView do
 
   def address_line_template(recipient, fields) do
     fields
-    |> Enum.map(&Map.get(recipient, &1, ""))
-    |> Enum.join(" ")
+    |> Enum.map_join(" ", &Map.get(recipient, &1, ""))
     |> String.replace(~r/\s+/, " ")
     |> String.trim()
   end

--- a/lib/store_web/views/product_view.ex
+++ b/lib/store_web/views/product_view.ex
@@ -15,9 +15,7 @@ defmodule Elementary.StoreWeb.ProductView do
 
     variants
     |> Enum.filter(fn v ->
-      Enum.all?(same_keys, &(Map.get(variant, &1) === Map.get(v, &1)))
-    end)
-    |> Enum.filter(fn v ->
+      Enum.all?(same_keys, &(Map.get(variant, &1) === Map.get(v, &1))) and
       Enum.all?(changes, fn {ck, cv} -> Map.get(v, ck) === cv end)
     end)
     |> List.first()


### PR DESCRIPTION
This fixes part of the CI that's currently failing because `credo` is giving us some refactoring suggestions.

The variable names aren't great in `product_view.ex` so I can't 100% tell what that function is doing, but the logic is equivalent, and I've tested that the size/color variants correctly show as available/unavailable when selecting different ones, which is what this method is used for.