### PR TITLE
printful: Switch to bearer auth

### DIFF
--- a/lib/printful/api.ex
+++ b/lib/printful/api.ex
@@ -18,7 +18,7 @@ defmodule Printful.Api do
       {Tesla.Middleware.BaseUrl, config[:baseUrl]},
       {Tesla.Middleware.Headers,
        [
-         {"Authorization", "Basic #{Base.encode64(config[:api_key])}"}
+         {"Authorization", "Bearer #{config[:api_key]}"}
        ]},
       {Tesla.Middleware.Retry,
        delay: 200,


### PR DESCRIPTION
They switched off basic auth March 30th. I've already generated a new Bearer token and added it to the DigitalOcean config:

https://help.printful.com/hc/en-us/articles/4632388335260-What-should-I-know-about-API-key-to-API-token-migration-