### PR TITLE
printful: Gracefully handle missing variants

### DIFF
--- a/lib/printful/catalog.ex
+++ b/lib/printful/catalog.ex
@@ -3,9 +3,13 @@ defmodule Printful.Catalog do
   Handles everything catalog related for Printful.
   """
 
-  alias Printful.Api
+  alias Printful.{Api, ApiError}
 
   def variant(id) do
-    Api.get("/products/variant/" <> to_string(id))
+    try do
+      {:ok, Api.get("/products/variant/" <> to_string(id))}
+    rescue
+      e in ApiError -> {:error, e}
+    end
   end
 end

--- a/lib/store/catalog/catalog.ex
+++ b/lib/store/catalog/catalog.ex
@@ -20,6 +20,8 @@ defmodule Elementary.Store.Catalog do
 
     products
     |> Enum.zip(variants)
+    |> Enum.filter(fn {_a, b} -> elem(b, 0) == :ok end)
+    |> Enum.map(fn {a, b} -> {a, elem(b, 1)} end)
     |> Enum.map(&Tuple.to_list/1)
     |> Enum.map(&apply(Product, :from_printful, &1))
   end
@@ -30,11 +32,19 @@ defmodule Elementary.Store.Catalog do
     catalog_variant_id = hd(product.sync_variants).product.variant_id
     catalog = Printful.Catalog.variant(catalog_variant_id)
 
+    if elem(catalog, 0) != :ok do
+      throw(elem(catalog, 1))
+    end
+
+    catalog = elem(catalog, 1)
+
     variants =
       product
       |> Map.get(:sync_variants)
       |> Enum.map(&Map.get(&1, :id))
       |> Enum.map(&get_variant/1)
+      |> Enum.filter(fn {a, _b} -> a == :ok end)
+      |> Enum.map(fn {_a, b} -> b end)
 
     product
     |> Product.from_printful(catalog)
@@ -46,12 +56,16 @@ defmodule Elementary.Store.Catalog do
     |> Map.get(:sync_variants)
     |> Enum.map(&Map.get(&1, :id))
     |> Enum.map(&get_variant/1)
+    |> Enum.filter(fn {a, _b} -> a == :ok end)
+    |> Enum.map(fn {_a, b} -> b end)
   end
 
   def get_variant(variant_id) do
     store = Printful.Store.variant(variant_id)
-    catalog = Printful.Catalog.variant(store.product.variant_id)
 
-    Variant.from_printful(store, catalog)
+    case Printful.Catalog.variant(store.product.variant_id) do
+      {:ok, catalog} -> {:ok, Variant.from_printful(store, catalog)}
+      {:error, reason} -> {:error, reason}
+    end
   end
 end

--- a/lib/store/catalog/catalog.ex
+++ b/lib/store/catalog/catalog.ex
@@ -14,13 +14,16 @@ defmodule Elementary.Store.Catalog do
     variants =
       products
       |> Enum.map(&Map.get(&1, :sync_variants))
+      # Get the first variant from the product to populate details with
       |> Enum.map(&hd/1)
       |> Enum.map(& &1.product.variant_id)
       |> Enum.map(&Printful.Catalog.variant/1)
 
     products
     |> Enum.zip(variants)
+    # Filter out any products with variant tuples in error state
     |> Enum.filter(fn {_a, b} -> elem(b, 0) == :ok end)
+    # Pull the result out of the ok/variant tuple
     |> Enum.map(fn {a, b} -> {a, elem(b, 1)} end)
     |> Enum.map(&Tuple.to_list/1)
     |> Enum.map(&apply(Product, :from_printful, &1))
@@ -32,10 +35,14 @@ defmodule Elementary.Store.Catalog do
     catalog_variant_id = hd(product.sync_variants).product.variant_id
     catalog = Printful.Catalog.variant(catalog_variant_id)
 
+    # Failed to get the first variant for a product, this is probably an actual
+    # error as we already filtered out products that don't have a first variant,
+    # so we throw here
     if elem(catalog, 0) != :ok do
       throw(elem(catalog, 1))
     end
 
+    # Pull the result out of the ok/variant tuple
     catalog = elem(catalog, 1)
 
     variants =
@@ -43,7 +50,9 @@ defmodule Elementary.Store.Catalog do
       |> Map.get(:sync_variants)
       |> Enum.map(&Map.get(&1, :id))
       |> Enum.map(&get_variant/1)
+      # Filter out error/variant tuples
       |> Enum.filter(fn {a, _b} -> a == :ok end)
+      # Pull the result out of the resulting ok/variant tuples
       |> Enum.map(fn {_a, b} -> b end)
 
     product
@@ -56,7 +65,9 @@ defmodule Elementary.Store.Catalog do
     |> Map.get(:sync_variants)
     |> Enum.map(&Map.get(&1, :id))
     |> Enum.map(&get_variant/1)
+    # Filter out variants that returned errors in the api
     |> Enum.filter(fn {a, _b} -> a == :ok end)
+    # Pull the result out of the resulting ok/variant tuples
     |> Enum.map(fn {_a, b} -> b end)
   end
 


### PR DESCRIPTION
Instead of crashing the whole site when a Printful variant gets removed and returns a 404 in the API, just throw away that variant/product and don't display it.