### PR TITLE
Only check gzip key at compile time

### DIFF
--- a/lib/store_web/endpoint.ex
+++ b/lib/store_web/endpoint.ex
@@ -19,7 +19,7 @@ defmodule Elementary.StoreWeb.Endpoint do
   plug Plug.Static,
     at: "/",
     from: :store,
-    gzip: Application.compile_env(:store, __MODULE__)[:gzip]
+    gzip: Application.compile_env(:store, [__MODULE__, :gzip], false)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.


### PR DESCRIPTION
This fixes the deployment issues since https://github.com/elementary/store/commit/f1721979e4b34d10ec4aef41a6baad379c7f73d3

Instead of checking all config at compile time, only check the gzip key.